### PR TITLE
Refine UI

### DIFF
--- a/ios/BeaconBroadcaster/BeaconBroadcaster/MainTabView.swift
+++ b/ios/BeaconBroadcaster/BeaconBroadcaster/MainTabView.swift
@@ -20,6 +20,6 @@ struct MainTabView: View {
                     Label("Users", systemImage: "person.3.fill")
                 }
         }
-        .accentColor(.blue)
+        .tint(.blue)
     }
 }

--- a/ios/BeaconBroadcaster/BeaconBroadcaster/UserHistoryView.swift
+++ b/ios/BeaconBroadcaster/BeaconBroadcaster/UserHistoryView.swift
@@ -12,17 +12,22 @@ struct UserHistoryView: View {
   @EnvironmentObject var session: AdminSessionStore
   let user: AdminUser
 
+  static let dateTimeFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.locale = Locale(identifier: "en_US_POSIX")
+    f.dateStyle = .medium
+    f.timeStyle = .short
+    return f
+  }()
+
   var body: some View {
     List {
       if session.selectedHistory.isEmpty {
-        Text("Loading…")
+        Text("Fetching records…")
       }
       ForEach(session.selectedHistory) { rec in
         HStack {
-          // show both date and time
-          Text(rec.date, style: .date)
-          Text(rec.date, style: .time)
-            .foregroundColor(.secondary)
+          Text(rec.date, formatter: Self.dateTimeFormatter)
           Spacer()
           Text(rec.status)
             .foregroundColor(rec.status.hasPrefix("✅") ? .green : .red)

--- a/ios/BeaconBroadcaster/BeaconBroadcaster/UsersListView.swift
+++ b/ios/BeaconBroadcaster/BeaconBroadcaster/UsersListView.swift
@@ -33,9 +33,10 @@ struct UsersListView: View {
                             Text(user.username)
                         }
                     }
+                    .refreshable { fetchUsers() }
                 }
             }
-            .navigationTitle("All Users")
+            .navigationTitle("User Accounts")
             .toolbar {
                 // pull-to-refresh button
                 ToolbarItem(placement: .navigationBarTrailing) {

--- a/ios/DataLogger/ProverApp/AttendanceView.swift
+++ b/ios/DataLogger/ProverApp/AttendanceView.swift
@@ -66,11 +66,15 @@ struct AttendanceView: View {
                   .padding(.top)
             }
 
-            Button("Start Capture & Scan") {
+            Button(action: {
                 startContinuousCapture()
                 lastBeaconTime = Date()
                 startSampling()
+            }) {
+                Text("Start Attendance Session")
+                    .frame(maxWidth: .infinity)
             }
+            .buttonStyle(.borderedProminent)
             .padding(.top)
 
             Text(proofResult)

--- a/ios/DataLogger/ProverApp/HistoryView.swift
+++ b/ios/DataLogger/ProverApp/HistoryView.swift
@@ -16,7 +16,6 @@ struct HistoryView: View {
         NavigationView {
             List(session.history) { rec in
                 HStack {
-                    // 2️⃣ Use our new formatter:
                     Text(rec.date, formatter: Self.dateTimeFormatter)
                     Spacer()
                     Text(rec.status)
@@ -27,6 +26,7 @@ struct HistoryView: View {
                         )
                 }
             }
+            .refreshable { session.fetchHistory() }
             .onAppear { session.fetchHistory() }
             .navigationTitle("Attendance History")
             .toolbar {

--- a/ios/DataLogger/ProverApp/HomeView.swift
+++ b/ios/DataLogger/ProverApp/HomeView.swift
@@ -10,5 +10,6 @@ struct HomeView: View {
       HistoryView()
         .tabItem { Label("History",    systemImage: "clock.fill") }
     }
+    .tint(.blue)
   }
 }

--- a/ios/DataLogger/ProverApp/LoginView.swift
+++ b/ios/DataLogger/ProverApp/LoginView.swift
@@ -7,22 +7,28 @@ struct LoginView: View {
     @State private var showSignup = false
 
     var body: some View {
-        VStack(spacing:20) {
-            Text("ZK Attendance").font(.largeTitle)
+        VStack(spacing: 24) {
+            Text("ZK Attendance")
+                .font(.largeTitle.bold())
             TextField("Username", text: $username)
                 .textFieldStyle(.roundedBorder)
                 .autocapitalization(.none)
+                .autocorrectionDisabled(true)
             SecureField("Password", text: $password)
                 .textFieldStyle(.roundedBorder)
 
-            Button("Log In") {
+            Button(action: {
                 session.login(username: username, password: password) { ok in
                     if !ok {
                         // show error alert
                         showSignup = false
                     }
                 }
+            }) {
+                Text("Log In")
+                    .frame(maxWidth: .infinity)
             }
+            .buttonStyle(.borderedProminent)
             .disabled(username.isEmpty || password.isEmpty)
             .alert(item: Binding(
               get: { session.errorMessage.map { ErrorWrapper($0) } },

--- a/ios/DataLogger/ProverApp/SignupView.swift
+++ b/ios/DataLogger/ProverApp/SignupView.swift
@@ -16,17 +16,19 @@ struct SignupView: View {
     @State private var showingAlert = false
 
     var body: some View {
-        VStack(spacing:20) {
-            Text("Sign Up").font(.largeTitle)
+        VStack(spacing: 24) {
+            Text("Create Account")
+                .font(.largeTitle.bold())
             TextField("Username", text: $username)
                 .textFieldStyle(.roundedBorder)
                 .autocapitalization(.none)
+                .autocorrectionDisabled(true)
             SecureField("Password", text: $password)
                 .textFieldStyle(.roundedBorder)
             SecureField("Confirm", text: $confirm)
                 .textFieldStyle(.roundedBorder)
 
-            Button("Create Account") {
+            Button(action: {
                 guard password == confirm, !username.isEmpty else {
                     session.errorMessage = "Passwords must match"
                     showingAlert = true
@@ -41,7 +43,11 @@ struct SignupView: View {
                         showingAlert = true
                     }
                 }
+            }) {
+                Text("Sign Up")
+                    .frame(maxWidth: .infinity)
             }
+            .buttonStyle(.borderedProminent)
             .disabled(username.isEmpty || password.isEmpty)
             .alert(isPresented: $showingAlert) {
                 Alert(title: Text("Signup"),


### PR DESCRIPTION
## Summary
- polish login and signup screens with clearer layout
- update attendance view button text and style
- apply a blue tint to tab navigation
- allow pull-to-refresh on history lists
- improve admin user list and history screens

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68500751a31083228f9743dc006f008a