### PR TITLE
Combine broadcaster and student apps

### DIFF
--- a/ios/AttendanceApp/AppLoginView.swift
+++ b/ios/AttendanceApp/AppLoginView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+private struct ErrorWrapper: Identifiable {
+    let id = UUID()
+    let msg: String
+}
+
+struct AppLoginView: View {
+    @EnvironmentObject var session: RootSession
+    @State private var username = ""
+    @State private var password = ""
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("ZK Attendance")
+                .font(.largeTitle.bold())
+            TextField("Username", text: $username)
+                .textFieldStyle(.roundedBorder)
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+            SecureField("Password", text: $password)
+                .textFieldStyle(.roundedBorder)
+
+            Button(action: {
+                session.login(username: username, password: password)
+            }) {
+                Text("Log In")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(username.isEmpty || password.isEmpty)
+        }
+        .padding()
+        .alert(item: Binding<ErrorWrapper?>(
+            get: { session.errorMessage.map { ErrorWrapper(msg: $0) } },
+            set: { _ in session.errorMessage = nil }
+        )) { err in
+            Alert(title: Text("Login Error"), message: Text(err.msg), dismissButton: .default(Text("OK")))
+        }
+    }
+}

--- a/ios/AttendanceApp/AttendanceApp.swift
+++ b/ios/AttendanceApp/AttendanceApp.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import CoreLocation
+
+@main
+struct AttendanceApp: App {
+    @StateObject private var rootSession = RootSession()
+    @StateObject private var broadcaster = BeaconBroadcaster()
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+
+    var body: some Scene {
+        WindowGroup {
+            switch rootSession.role {
+            case .student:
+                HomeView()
+                    .environmentObject(rootSession.student)
+            case .admin:
+                MainTabView()
+                    .environmentObject(rootSession.admin)
+                    .environmentObject(broadcaster)
+            case .none:
+                AppLoginView()
+                    .environmentObject(rootSession)
+            }
+        }
+    }
+}
+
+// copied from BeaconBroadcasterApp so location permissions work
+class AppDelegate: NSObject, UIApplicationDelegate, CLLocationManagerDelegate {
+    private let locMgr = CLLocationManager()
+
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        locMgr.delegate = self
+        locMgr.requestWhenInUseAuthorization()
+        return true
+    }
+
+    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        if status == .authorizedWhenInUse {
+            manager.requestAlwaysAuthorization()
+        }
+    }
+}

--- a/ios/AttendanceApp/RootSession.swift
+++ b/ios/AttendanceApp/RootSession.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Combine
+
+final class RootSession: ObservableObject {
+    enum Role {
+        case none
+        case student
+        case admin
+    }
+
+    @Published var role: Role = .none
+    @Published var errorMessage: String?
+
+    // child sessions for student and admin flows
+    let student = SessionStore()
+    let admin   = AdminSessionStore()
+
+    func login(username: String, password: String) {
+        // First try admin login
+        admin.login(username: username, password: password) { success in
+            if success {
+                DispatchQueue.main.async {
+                    self.role = .admin
+                }
+            } else {
+                // attempt student login
+                self.admin.errorMessage = nil
+                self.student.login(username: username, password: password) { ok in
+                    DispatchQueue.main.async {
+                        if ok {
+                            self.role = .student
+                        } else {
+                            self.errorMessage = self.student.errorMessage
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func logout() {
+        student.logout()
+        admin.logout()
+        role = .none
+    }
+}

--- a/ios/BeaconBroadcaster/BeaconBroadcaster/BeaconBroadcaster.swift
+++ b/ios/BeaconBroadcaster/BeaconBroadcaster/BeaconBroadcaster.swift
@@ -7,19 +7,31 @@ final class BeaconBroadcaster: NSObject,
                               CBPeripheralManagerDelegate,
                               ObservableObject
 {
-    private var pm: CBPeripheralManager!
+    private var pm: CBPeripheralManager?
+    private var timer: Timer?
     /// Base UUID with a fixed first 8 bytes; last 8 bytes will hold our nonce.
     private let baseUuidString = "D4F56A24-9CDE-4B12-ABCD-000000000000"
 
     override init() {
         super.init()
+    }
+
+    /// Begin broadcasting beacons
+    func start() {
         pm = CBPeripheralManager(delegate: self, queue: nil)
+    }
+
+    /// Stop broadcasting
+    func stop() {
+        timer?.invalidate(); timer = nil
+        pm?.stopAdvertising();
+        pm = nil
     }
 
     func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
         guard peripheral.state == .poweredOn else { return }
         advertise()
-        Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { _ in
+        timer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { _ in
             self.advertise()
         }
     }

--- a/ios/BeaconBroadcaster/BeaconBroadcaster/BroadcastView.swift
+++ b/ios/BeaconBroadcaster/BeaconBroadcaster/BroadcastView.swift
@@ -8,6 +8,7 @@ struct BroadcastView: View {
     Text("🔊 Beacon Broadcaster Running…")
       .multilineTextAlignment(.center)
       .padding()
-      .onAppear { /* nothing to do here—the manager lives in App */ }
+      .onAppear { broadcaster.start() }
+      .onDisappear { broadcaster.stop() }
   }
 }


### PR DESCRIPTION
## Summary
- add new `AttendanceApp` SwiftUI target that decides which interface to show
- `RootSession` decides admin vs student login
- login screen now uses `RootSession`
- broadcaster only starts after admin login